### PR TITLE
fix: 多分直ったはず

### DIFF
--- a/frontend/src/app/start/page.tsx
+++ b/frontend/src/app/start/page.tsx
@@ -10,6 +10,7 @@ type RankingState = {
     data: UserRankingEntry[];
     loading: boolean;
     error: string | null;
+    loaded: boolean;
 };
 
 type RankingConfig = {
@@ -55,9 +56,9 @@ const rankingPeriods: RankingPeriod[] = ["total", "monthly", "weekly"];
 export default function StartPage() {
     const [activePeriod, setActivePeriod] = useState<RankingPeriod>("total");
     const [rankings, setRankings] = useState<Record<RankingPeriod, RankingState>>({
-        total: { data: [], loading: false, error: null },
-        monthly: { data: [], loading: false, error: null },
-        weekly: { data: [], loading: false, error: null },
+        total: { data: [], loading: false, error: null, loaded: false },
+        monthly: { data: [], loading: false, error: null, loaded: false },
+        weekly: { data: [], loading: false, error: null, loaded: false },
     });
 
     const loadRanking = useCallback(async (period: RankingPeriod) => {
@@ -69,19 +70,24 @@ export default function StartPage() {
             const list = await apiGetRanking(5, period);
             setRankings((prev) => ({
                 ...prev,
-                [period]: { data: list, loading: false, error: null },
+                [period]: { data: list, loading: false, error: null, loaded: true },
             }));
         } catch (err) {
             setRankings((prev) => ({
                 ...prev,
-                [period]: { ...prev[period], loading: false, error: formatApiError(err) },
+                [period]: {
+                    ...prev[period],
+                    loading: false,
+                    error: formatApiError(err),
+                    loaded: true,
+                },
             }));
         }
     }, []);
 
     useEffect(() => {
         const state = rankings[activePeriod];
-        if (state.loading || state.data.length > 0 || state.error) return;
+        if (state.loading || state.loaded) return;
         void loadRanking(activePeriod);
     }, [activePeriod, rankings, loadRanking]);
 


### PR DESCRIPTION
## 概要
ユーザランキングを正しく表示できるようにする

## 関連Issue
issue立ててないです

- Closes #
- Related #

## 変更内容
- 空配列が返ると `data.length > 0` を満たさず、useEffect が毎回再実行されて無限に叩き続けてた

## 動作確認

<!-- 実行したコマンド / 画面操作 / API手順など -->

- [x] backend: `cd backend && uv run ruff check app`
- [x] backend: `cd backend && uv run python -m compileall app`
- [x] frontend: `cd frontend && npm run lint`
- [x] frontend: `cd frontend && npm run build`

## スクリーンショット（UI変更がある場合）
<img width="990" height="347" alt="スクリーンショット 2025-12-21 5 56 40" src="https://github.com/user-attachments/assets/f012f2a8-df5c-4358-ab94-892e043da40d" />
<img width="993" height="346" alt="スクリーンショット 2025-12-21 5 56 52" src="https://github.com/user-attachments/assets/05209c2b-e926-4552-b359-a7a10a03b9a7" />
<img width="1004" height="349" alt="スクリーンショット 2025-12-21 5 57 43" src="https://github.com/user-attachments/assets/614cc2f0-25ea-4024-aa0c-d9c5a5e5e84e" />


## 影響範囲 / 補足

<!-- マイグレーション、環境変数、互換性など -->
